### PR TITLE
Fix hard-coded indent-width settings

### DIFF
--- a/app/js/editor.js
+++ b/app/js/editor.js
@@ -53,6 +53,8 @@ define(function(require, exports, module) {
                 require(["./session_manager"], function(session_manager) {
                     var sessions = session_manager.getSessions();
                     Object.keys(sessions).forEach(function(path) {
+                        sessions[path].setTabSize(settings.get("tabSize"));
+                        sessions[path].setUseSoftTabs(settings.get("useSoftTabs"));
                         sessions[path].setUseWrapMode(settings.get("wordWrap"));
                     });
                 });


### PR DESCRIPTION
It appears that zed ignores the tab settings.  I got it to work on mine with this setting.  However, the beautify tool still seems to be hard-coded to 4 spaces indent.  I couldn't find where to fix that.
