### PR TITLE
Add some more modes.

### DIFF
--- a/app/settings/all
+++ b/app/settings/all
@@ -1,5 +1,6 @@
 /keys.default.json
 /keys.user.json
+/mode/c.default.json
 /mode/coffee.default.json
 /mode/css.default.json
 /mode/dart.default.json
@@ -12,6 +13,7 @@
 /mode/php.default.json
 /mode/python.default.json
 /mode/ruby.default.json
+/mode/sh.default.json
 /mode/text.default.json
 /mode/xml.default.json
 /settings.default.json

--- a/app/settings/mode/c.default.json
+++ b/app/settings/mode/c.default.json
@@ -1,0 +1,5 @@
+{
+    "name": "C",
+    "highlighter": "ace/mode/c_cpp",
+    "extensions": ["c", "h", "cpp", "cxx", "hpp", "hxx"]
+}

--- a/app/settings/mode/coffee.default.json
+++ b/app/settings/mode/coffee.default.json
@@ -1,7 +1,7 @@
 {
     "name": "CoffeeScript",
     "highlighter": "ace/mode/coffee",
-    "extensions": ["cs"],
+    "extensions": ["cs", "coffee"],
     "tool:preview": {
         "scriptUrl": "plugin/preview/coffee.js"
     },

--- a/app/settings/mode/sh.default.json
+++ b/app/settings/mode/sh.default.json
@@ -1,0 +1,5 @@
+{
+    "name": "Shell",
+    "highlighter": "ace/mode/sh",
+    "extensions": ["sh"]
+}


### PR DESCRIPTION
After filing issues against your ace builds, I realized the mode stuff was all related to zed.  This PR adds C/C++, Shell, and adds the .coffee extension to the coffeescript mode.
