### PR TITLE
RHTML mode

### DIFF
--- a/app/config/default/mode/rhtml.json
+++ b/app/config/default/mode/rhtml.json
@@ -1,0 +1,7 @@
+{
+    "rhtml": {
+        "name": "RHTML",
+        "highlighter": "ace/mode/rhtml",
+        "extensions": ["rhtml", "html.erb"]
+    }
+}

--- a/app/config/default/modes.json
+++ b/app/config/default/modes.json
@@ -25,6 +25,7 @@
         "/default/mode/plist.json",
         "/default/mode/protobuf.json",
         "/default/mode/python.json",
+        "/default/mode/rhtml.json",
         "/default/mode/ruby.json",
         "/default/mode/sh.json",
         "/default/mode/text.json",

--- a/app/js/lib/path.js
+++ b/app/js/lib/path.js
@@ -14,13 +14,13 @@ define(function(require, exports, module) {
         var parts = path.split("/");
         return parts[parts.length - 1];
     };
-    
+
     exports.ext = function(path) {
         var filename = exports.filename(path);
         var parts = filename.split('.');
         if(parts.length === 1) {
             return null;
         }
-        return parts[parts.length - 1];
+        return parts.slice(1).join(".");
     };
 });


### PR DESCRIPTION
An RHTML mode for Rails users. Also tweaks path.js to allow multipart extensions (ex. html.erb, tar.gz).
