### PR TITLE
Added globals support to JSHint check.

### DIFF
--- a/app/config/default/mode/javascript/check.js
+++ b/app/config/default/mode/javascript/check.js
@@ -128,8 +128,13 @@ define(function(require, exports, module) {
             // report them as error only if code is actually invalid
             var maxErrorLevel = isValidJS(value) ? "warning" : "error";
 
+            var globals;
+            if (info.options) {
+                globals = info.options.globals;
+            }
+
             // var start = new Date();
-            lint(value, info.options);
+            lint(value, info.options, globals);
             var results = lint.errors;
 
             for (var i = 0; i < results.length; i++) {


### PR DESCRIPTION
Currently Zed only allows to override options passed to JSHint check command.

Now it is possible to also pass custom globals if project requires them.

For example in ./zedconfig.json you can put

``` json
{
    "modes": {
        "javascript": {
            "commands": {
                "Tools:Check": {
                    "options": {
                        "globals": {
                            "READONLY_GLOBAL": false,
                            "WRITABLE_GLOBAL": true
                        }
                    }
                }
            }
        }
    }
}
```

As discussed in https://groups.google.com/forum/#!topic/zed-user/Xe4AdaO7PgE
