### PR TITLE
quick fix for incorrectly underlined identifiers when using tabs

### DIFF
--- a/app/config/default/mode/javascript/check.js
+++ b/app/config/default/mode/javascript/check.js
@@ -101,7 +101,7 @@ module.exports = function(info, callback) {
         // var start = new Date();
         lint(value, info.options, globals);
         var results = lint.errors;
-
+        
         for (var i = 0; i < results.length; i++) {
             var error = results[i];
             if (!error) continue;
@@ -130,6 +130,14 @@ module.exports = function(info, callback) {
             }
 
             var line = lines[error.line - 1];
+            
+            if (line) {
+                var match = line.match(/\t/g);
+                if (match) {
+                    error.character -= (match.length * 3);
+                }
+            }
+            
             var pos = findIdentifierRange(line, error.character - 1);
             // console.log("Error", error, pos);
 


### PR DESCRIPTION
Quick fix for #101.

jshint seems to assume by default that 1 tab = 4 spaces.  It then returns a column where an error occurs.  findIdentifierRange in check.js for the javascript mode treats the column int like it's an index in a character array rather than a column displayed in an editor.  This fix causes those to work out, unless someone puts a tab after the error column.

I thought jshint would have an option that specified the length of a tab, but I messed with the indent option and had no luck so I just hard coded in to reduce by 3.  This feels wrong but seems to work ok.
