### PR TITLE
autoIndentOnPaste when first line has leading whitespace

### DIFF
--- a/app/js/editor.js
+++ b/app/js/editor.js
@@ -280,6 +280,7 @@ define(function(require, exports, module) {
                     lines[i] = add + lines[i];
                 }
             }
+            lines[0] = lines[0].substring(lines[0].search(regexp));
             e.text = lines.join("\n");
             if (!config.getPreference("useSoftTabs", session)) {
                 regexp = new RegExp(tabAsSpaces, "gm");


### PR DESCRIPTION
Right now when you paste a block whose first line has leading whitespace that line is indented too much.  I've come up with 2 different solutions to this:
- remove any leading whitespace from the first line
- indent the other lines more to match up with the first line

This pull request implements the first option.  I have no real opinion on which one is preferable and both are really easy to implement.  I just think the way it works now is incorrect.  What do you guys think?
