### PR TITLE
Fixed auto indent on paste when pasting over a selection

### DIFF
--- a/app/js/editor.js
+++ b/app/js/editor.js
@@ -239,7 +239,7 @@ define(function(require, exports, module) {
     };
     
     function autoIndentOnPaste(editor, session, e) {
-        var pos = editor.getCursorPosition();
+        var pos = editor.getSelectionRange().start;
         var line = editor.getSession().getLine(pos.row);
         var tabSize = config.getPreference("tabSize", session);
         var col = pos.column;


### PR DESCRIPTION
Fixed so it bases the indenting on the start of the selection range instead of the current cursor position.
