### PR TITLE
Docs: Example "zed" mode config should be under a "zed" key

### DIFF
--- a/app/manual/configuration.md
+++ b/app/manual/configuration.md
@@ -112,26 +112,28 @@ Let's start with a simple new "zed" mode:
 
     {
         "modes": {
-            "name": "Zed",
-            "highlighter": "ace/mode/markdown",
-            "extensions": ["zed"],
-
-            "commands": {
-                "Tools:Check": {
-                    "scriptUrl": "/user/mode/zed/check.js"
+            "zed" : {
+                "name": "Zed",
+                "highlighter": "ace/mode/markdown",
+                "extensions": ["zed"],
+                
+                "commands": {
+                    "Tools:Check": {
+                        "scriptUrl": "/user/mode/zed/check.js"
+                    }
+                },
+                
+                "handlers": {
+                    "check": ["Tools:Check"]
+                },
+                
+                "keys": {
+                    "Tools:Check": "Ctrl-C"
+                },
+                
+                "preferences": {
+                    "fontSize": 20
                 }
-            },
-
-            "handlers": {
-                "check": ["Tools:Check"]
-            },
-
-            "keys": {
-                "Tools:Check": "Ctrl-C"
-            },
-
-            "preferences": {
-                "fontSize": 20
             }
         }
     }


### PR DESCRIPTION
I think this is correct - it was the only way to make the VHDL mode work and otherwise I don't see how zed could separate multiple mode declarations.
