### PR TITLE
Include "scss" as an extension for Sass

### DIFF
--- a/app/config/default/mode/sass.json
+++ b/app/config/default/mode/sass.json
@@ -3,7 +3,7 @@
         "sass": {
             "name": "Sass",
             "highlighter": "ace/mode/sass",
-            "extensions": ["sass", "css.sass"]
+            "extensions": ["sass", "css.sass", "scss"]
         }
     }
 }


### PR DESCRIPTION
While some syntax highlighting might be slightly off due to the
differences between Sass and SCSS, it is certainly better than no
syntax highlighting at all.

I have tested the highlighting on a few .scss files, and the syntax
highlighting works quite well.
