### PR TITLE
Added SCSS as a separate mode

### DIFF
--- a/app/config/default/mode/sass.json
+++ b/app/config/default/mode/sass.json
@@ -3,7 +3,7 @@
         "sass": {
             "name": "Sass",
             "highlighter": "ace/mode/sass",
-            "extensions": ["sass", "css.sass", "scss"]
+            "extensions": ["sass", "css.sass"]
         }
     }
 }

--- a/app/config/default/mode/scss.json
+++ b/app/config/default/mode/scss.json
@@ -1,0 +1,9 @@
+{
+    "modes": {
+        "sass": {
+            "name": "SCSS",
+            "highlighter": "ace/mode/scss",
+            "extensions": ["scss"]
+        }
+    }
+}


### PR DESCRIPTION
Ace supports SCSS separately from Sass, so they should be in separate
configs.
