### PR TITLE
Don't split string just for counting "\n"

### DIFF
--- a/app/config/default/command/search.js
+++ b/app/config/default/command/search.js
@@ -5,9 +5,18 @@ var session = require("zed/session");
 var filterExtensions = ["pdf", "gz", "tgz", "bz2", "zip",
     "exe", "jpg", "jpeg", "gif", "png"];
 
+function count(str, searchchar, start, end) {
+    start = typeof start !== 'undefined' ? start : 0;
+    end = typeof end !== 'undefined' ? end : str.length;
+    var result = 0;
+    while ((start = str.indexOf(searchchar, start + 1)) != -1 && start < end) {
+        ++result;
+    }
+    return result;
+}
+
 function indexToLine(text, index) {
-    var s = text.substring(0, index);
-    return s.split("\n").length;
+    return count(text, '\n', 0, index) + 1;
 }
 
 function getLine(text, index) {


### PR DESCRIPTION
No need to split a text into lines just to count the number of '\n'.
This involves allocation twice amount of memory for a simple
character count. The bigger the file, the more memory you allocate
w/o any need.

http://jsperf.com/string-split-vs-for-loop-count/4

I'm curious though if you just simply don't care about memory consumption. Feel free to drop my pull request if so.
