### PR TITLE
Add option to turn off specific CSSLint rules

### DIFF
--- a/app/config/default/mode/css.json
+++ b/app/config/default/mode/css.json
@@ -14,6 +14,7 @@
                 },
                 "Tools:Check": {
                     "scriptUrl": "/default/mode/css/check.js",
+                    "options": {},
                     "inputs": {
                         "text": true
                     },

--- a/app/config/default/mode/css/check.js
+++ b/app/config/default/mode/css/check.js
@@ -5,7 +5,12 @@ var CSSLint = require("./csslint.js").CSSLint;
  */
 module.exports = function(info) {
     var text = info.inputs.text;
-    var result = CSSLint.verify(text);
+    var rules = CSSLint.getRuleset();
+    if (info.options) {
+        setRules(rules, info.options);
+    }
+
+    var result = CSSLint.verify(text, rules);
     return result.messages.map(function(msg) {
         return {
             row: msg.line - 1,
@@ -15,3 +20,11 @@ module.exports = function(info) {
         };
     });
 };
+
+function setRules(rules, options) {
+    Object.keys(options).forEach(function(k) {
+        if (options[k] === false) {
+            delete rules[k];
+        }
+    });
+}


### PR DESCRIPTION
This adds a config option to turn off specific CSSLint rules. For example I am currently using a CSS processor that includes `@import`ed files, which means that the `@import` warning is totally irrelevant for me. This change allows me to disable that specific warning, while still using CSSLint.

Example config to quit warning on `@import` statements in CSS:

``` js
{
    "modes": {
        "css": {
            "commands": {
                "Tools:Check": {
                    "options": {
                        "import": false
                    }
                }
            }
        }
    }
}
```
