### PR TITLE
Add support for setting ace keybinding

### DIFF
--- a/app/config/default/preferences.json
+++ b/app/config/default/preferences.json
@@ -35,6 +35,7 @@
         "wordWrapColumn": null,
         "wrapBehaviorsEnabled": false,
         "continuousCompletion": false,
-        "continuousCompletionDelay": 250
+        "continuousCompletionDelay": 250,
+        "keybinding": "ace"
     }
 }

--- a/app/js/editor.js
+++ b/app/js/editor.js
@@ -74,6 +74,11 @@ define(function(require, exports, module) {
                 } else {
                     edit.removeAllListeners("paste");
                 }
+                edit.setKeyboardHandler({
+                    vim: "ace/keyboard/vim",
+                    emacs: "ace/keyboard/vim",
+                    ace: null
+                }[config.getPreference("keybinding", session)]);
             },
             setSessionConfiguration: function(session) {
                 session.setTabSize(config.getPreference("tabSize", session));


### PR DESCRIPTION
To allow running zed commands like `ctrl-.` in vim normal mode ace from https://github.com/ajaxorg/ace/pull/1904 is required
