### PR TITLE
default language mode for Groovy

### DIFF
--- a/app/config/default/mode/groovy.json
+++ b/app/config/default/mode/groovy.json
@@ -1,0 +1,11 @@
+{
+    modes: {
+        groovy: {
+            name: "Groovy",
+            highlighter: "ace/mode/groovy",
+            extensions: [
+                "groovy"
+            ]
+        }
+    }
+}


### PR DESCRIPTION
It's a small thing, but I noted that Ace had a mode built in for the Groovy programming language, and since I've been using an increasing amount of Groovy lately, I thought I would add a default mode to Zed.
