### PR TITLE
Trim whitespace from remote URLs

### DIFF
--- a/app/js/open.js
+++ b/app/js/open.js
@@ -64,6 +64,8 @@ define(function(require, exports, module) {
             if (!url) {
                 return;
             }
+            url = url.trim();
+
             // Only check http(s) links
             if (url.indexOf("http") !== 0) {
                 $("#hint").html("<span class='error'>ERROR</span>: URL does not seem to run a (recent) Zed server.");


### PR DESCRIPTION
I just started to find my way around Zed's code. I have a few small things I'd like to contribute in the future, but let's start with something small :D

Sometimes I accidentally include leading spaces from the output of `zedrem` which makes opening that project fails. I think Zed should and could take of that for me.
