### PR TITLE
Add JSX mode definition

### DIFF
--- a/app/config/default/mode/jsx.json
+++ b/app/config/default/mode/jsx.json
@@ -1,0 +1,11 @@
+{
+    modes: {
+        jsx: {
+            name: "JSX",
+            highlighter: "ace/mode/jsx",
+            extensions: [
+                "jsx"
+            ]
+        }
+    }
+}

--- a/app/config/default/modes.json
+++ b/app/config/default/modes.json
@@ -15,6 +15,7 @@
         "./mode/ini.json",
         "./mode/jack.json",
         "./mode/java.json",
+        "./mode/jsx.json",
         "./mode/less.json",
         "./mode/logiql.json",
         "./mode/lua.json",


### PR DESCRIPTION
This adds a mode configuration file for React's [JSX files](http://facebook.github.io/react/docs/jsx-in-depth.html), using the highlighter [added to Ace](https://github.com/ajaxorg/ace/pull/794).
