### PR TITLE
Fix ZPM urls to use githubusercontent.com and remove trailing slash

### DIFF
--- a/app/config/default/zpm/zpm.js
+++ b/app/config/default/zpm/zpm.js
@@ -25,9 +25,9 @@ function uriToUrl(uri) {
     var repoPath = repoParts.slice(2).join('/');
     var branch = parts[2] || 'master';
     if (parts[0] === 'gh') {
-        return "https://raw.github.com/" + repoUsername + "/" + repoName + "/" + branch + "/" + repoPath + "/";
+        return "https://raw.githubusercontent.com/" + repoUsername + "/" + repoName + "/" + branch + "/" + (repoPath ? (repoPath + "/") : "");
     } else if (parts[0] === 'bb') {
-        return "https://bitbucket.org/" + repoUsername + "/" + repoName + "/raw/" + branch + "/" + repoPath + "/";
+        return "https://bitbucket.org/" + repoUsername + "/" + repoName + "/raw/" + branch + "/" + (repoPath ? (repoPath + "/") : "");
     }
     return uri;
 }


### PR DESCRIPTION
This changes ZPM to use the `raw.githubusercontent.com` domain which Github [recently changed](https://developer.github.com/changes/2014-04-25-user-content-security/). It also fixes the double trailing slash for the `package.json` URL (such as `https://...//package.json`).

Before these changes I couldn't install any packages (I was trying the `zedapp/jsx-mode` package).
