### PR TITLE
Fullscreen key combo on a mac is Command+Ctrl+F

### DIFF
--- a/app/config/default/keys.json
+++ b/app/config/default/keys.json
@@ -304,7 +304,10 @@
             "mac": "Command-W",
             "win": "Alt-F4|Ctrl-W"
         },
-        "Window:Fullscreen": "F11",
+        "Window:Fullscreen": {
+          "mac": "Command+Ctrl+F",
+          "win": "F11"
+        },
         "Configuration:Preferences:Increase Font Size": {
             "mac": "Command-=",
             "win": "Ctrl-+"


### PR DESCRIPTION
This changes the default fullscreen key combo on a mac from the default **F11** to the more common **Command+Ctrl+F**.
