### PR TITLE
Sandbox: HTTP POST extension

### DIFF
--- a/app/config/api/zed/http.js
+++ b/app/config/api/zed/http.js
@@ -6,6 +6,28 @@ module.exports = {
     get: function(url, type) {
         return sandboxRequest("zed/http", "get", [url, type]);
     },
+
+    /**
+     * Sends a HTTP POST request to the given URL.
+     * 
+     * options:
+     * 
+     *     headers: {Object}
+     *
+     *         The HTTP headers
+     * 
+     *     data: {Object || String} (optional)
+     * 
+     *          The HTTP request body payload.
+     *
+     *     type: {String} (optional; default = Intelligent Guess)
+     * 
+     *          The type of data expected from the server.
+     * 
+     * @param {String} url The respective endpoint.
+     * @param {Object} options The configuration object.
+     * 
+     */
     post: function(url, options) {
         return sandboxRequest("zed/http", "post", [url, options]);
     }

--- a/app/js/sandbox/zed/http.js
+++ b/app/js/sandbox/zed/http.js
@@ -13,17 +13,6 @@ define(function(require, exports, module) {
                 callback(jqXHR.status);
             });
         },
-
-        /**
-         * Sends a HTTP POST request to the given URL.
-         * 
-         * options:
-         * 
-         *     headers: {Object},
-         *     data: {Object || String}: Payload
-         *     type: {String}: Response MIME type
-         * 
-         */
         post: function(url, options, callback) {
             options = options || {};
 


### PR DESCRIPTION
Extension for the `http` sandbox API.

``` js
var http = require('zed/http');

http.post('http://host.tld/post', {
    data: {},
    headers: {},
    type: 'text/plain'
}).then(function (body) {
    console.log(body);
});
```
