### PR TITLE
Cannot call method 'slice' of undefined

### DIFF
--- a/app/config/default/zpm/zpm.js
+++ b/app/config/default/zpm/zpm.js
@@ -79,10 +79,7 @@ exports.install = function(uri) {
         if (installed[uri]) {
             throw new Error("Package already installed");
         }
-        if (!packageData.files) {
-            packageData.files = [];
-        }
-        files = packageData.files.slice(0);
+        files = (packageData.files || []).slice(0);
         files.push("config.json");
         var folder = uriToPath(uri) + "/";
         return configfs.writeFile(folder + "package.json", JSON5.stringify(packageData, null, 4));


### PR DESCRIPTION
When the class of `packageData` is `String`, then usage like below:

```
if (!packageData.files) {
    packageData.files = [];
    console.log(packageData.files); // we still got undefined here.
}
```

actually does not work. 

`files = packageData.files.slice(0);` would cause error 'Cannot call method 'slice' of undefined'.
