### PR TITLE
Fixed `dataType` in HTTP GET API.

### DIFF
--- a/app/js/sandbox/zed/http.js
+++ b/app/js/sandbox/zed/http.js
@@ -32,7 +32,7 @@ define(function(require, exports, module) {
         args.type = verb;
         args.headers = options.headers;
         args.data = options.data;
-        args.dataType = options.type;
+        args.dataType = options.dataType;
 
         return $.ajax(args);
     }


### PR DESCRIPTION
This is a fix for #369. The `dataType` was passed to jQuery in a wrong way. Therefore the deserialization of the `package.json` failed.
