### PR TITLE
Conversion of the HTTP response headers

### DIFF
--- a/app/js/sandbox/zed/http.js
+++ b/app/js/sandbox/zed/http.js
@@ -75,7 +75,7 @@ define(function(require, exports, module) {
 
         source.forEach(function onEntry (header) {
             var position = header.indexOf(':');
-            var key = header.substr(0, position).toLowerCase();
+            var key = header.substr(0, position);
             var value = header.substr(position + 1).trim();
 
             headers[key] = value;


### PR DESCRIPTION
The method `getAllResponseHeaders` of the XHR object returns a string with all response headers. In order to make the HTTP API more comfortable to use, this PR includes a function which converts the header information into an object.

Before:

```
Date: Wed, 11 Jun 2014 04:36:25 GMT
Server: Apache
...
```

After:

```
{
    Date: "Wed, 11 Jun 2014 04:36:25 GMT",
    Server: "Apache",
    ...
}
```
