### PR TITLE
Rename file fixes

### DIFF
--- a/app/js/session_manager.js
+++ b/app/js/session_manager.js
@@ -73,6 +73,11 @@ define(function(require, exports, module) {
             getSessions: function() {
                 return sessions;
             },
+            deleteSession: function(path) {
+                if (sessions[path]) {
+                    delete sessions[path];
+                }
+            }
         };
 
         function setupSave(session) {


### PR DESCRIPTION
Prevented deleting a file by renaming it to itself.  This is case insensitive for OS X since I believe mac filesystems are case insensitive by default.  Also displayed a confirm dialog when rename would overwrite another file.  Forced the session to reload when overwriting a file so that the overwritten file does not still display.  Also deleted files from the session when they are deleted (when renaming or deleting a file).
