### PR TITLE
add base16-default theme

### DIFF
--- a/app/config/all
+++ b/app/config/all
@@ -95,6 +95,7 @@
 /default/modes.json
 /default/preferences.json
 /default/theme/ambiance.css
+/default/theme/base16-default.css
 /default/theme/chaos.css
 /default/theme/chrome.css
 /default/theme/clouds.css

--- a/app/config/default/theme/base16-default.css
+++ b/app/config/default/theme/base16-default.css
@@ -1,0 +1,75 @@
+.base16-default {
+  background-color: #151515;
+  color: #d0d0d0;
+}
+
+.base16-default .ace_gutter {
+  background: #202020;
+  color: #505050;
+}
+
+.base16-default .ace_invisible {
+  color: #505050;
+}
+
+.base16-default .ace_print-margin {
+  width: 1px;
+  background: #505050;
+}
+
+.base16-default .ace_entity.ace_name.ace_tag,
+.base16-default .ace_keyword,
+.base16-default .ace_meta.ace_tag,
+.base16-default .ace_storage {
+  color: #f4bf75;
+}
+
+.base16-default .ace_constant.ace_character,
+.base16-default .ace_constant.ace_language,
+.base16-default .ace_constant.ace_numeric,
+.base16-default .ace_constant.ace_other {
+  color: #f4bf75;
+}
+
+.base16-default .ace_string {
+  color: #90a959;
+}
+
+.base16-default .ace_storage.ace_type,
+.base16-default .ace_support.ace_class,
+.base16-default .ace_support.ace_type {
+  color: #d28445;
+}
+
+.base16-default .ace_entity.ace_name.ace_function,
+.base16-default .ace_entity.ace_other,
+.base16-default .ace_entity.ace_other.ace_attribute-name,
+.base16-default .ace_variable {
+  color: #90a959;
+}
+
+.base16-default .ace_regexp {
+  color: #75b5aa;
+}
+
+.base16-default .ace_marker-layer .ace_selection {
+  background: #303030;
+}
+
+.base16-default.ace_multiselect .ace_selection.ace_start {
+  box-shadow: 0 0 3px 0px #303030;
+  border-radius: 2px;
+}
+
+.base16-default .ace_marker-layer .ace_active-line {
+  background: #303030;
+}
+
+.base16-default .ace_gutter-active-line {
+  background-color: #303030;
+  color: #b0b0b0;
+}
+
+.base16-default .ace_comment {
+  color: #505050;
+}

--- a/app/config/default/themes.json
+++ b/app/config/default/themes.json
@@ -197,6 +197,12 @@
             "dark": true,
             "cssClass": "ace-vibrant-ink",
             "css": "/default/theme/vibrant_ink.css"
+        },
+        "base16": {
+            "name": "Base 16",
+            "dark": true,
+            "cssClass": "base16-default",
+            "css": "/default/theme/base16-default.css"
         }
     }
 }


### PR DESCRIPTION
I used the [base16 builder](https://github.com/chriskempson/base16-builder) inspired by monokai theme
to provide values from base16.

Demo below. I was unable to test this unfortunately, because I got some errors when changing themes in the standalone version and I didn't want my browser configs reset by using local .crx. Please notify me if something else is needed to make this work. Also, I was not sure if there are requirements or a convention for styles, so I just followed monokai theme to style keywords/types etc how I wanted.

I could also make more themes from the base16 project, but a brief look at some other schemes gave weird result. This is only the base16-default scheme, but I thought it looked cool.

![async-js-base16-zed](https://cloud.githubusercontent.com/assets/345808/3528080/93160ec0-078b-11e4-919c-d6bdc8247626.png)
