### PR TITLE
Improved C++ symbol indexing support.

### DIFF
--- a/app/config/default/mode/c.json
+++ b/app/config/default/mode/c.json
@@ -19,15 +19,21 @@
                     inputs: {
                         text: true
                     },
-                    regexes: [{
-                        regex: "[a-zA-Z0-9_\\$]+\\s+([a-zA-Z0-9_\\$]+)\\s*\\([^\\)]*\\)\\s*\\{",
-                        symbolIndex: 1,
-                        type: "function"
-                    }, {
-                        regex: "struct\\s+([a-zA-Z0-9_\\$]+)\\s*\\{",
-                        symbolIndex: 1,
-                        type: "type"
-                    }]
+                    regexes: [
+                        {
+                            regex: "(\\w+\\s*\\([^;{)]*\\))\\s*(?:(->|:)[^;{]*)?(?:const|override|final|\\s)*\\{",
+                            symbolIndex: 1,
+                            type: "function"
+                        }, {
+                            regex: "(?:template\\s*<[^>]*>\\s*)?(?:class|struct|union)\\s+(?:(?:\\[\\[[\\s:\\w,\\(\\)\\'\\\"]*\\]\\])?\\s*(?:alignas\\s*\\(\\s*\\w*\\s*\\))?\\s*)*([a-zA-Z_][0-9a-zA-Z_]*)[^{;]*\\{",
+                            symbolIndex: 1,
+                            type: "type"
+                        }, {
+                            regex: "typedef\\s+[^;]*\\s+(\\w*)\\s*;",
+                            symbolIndex: 1,
+                            type: "type"
+                        }
+                    ]
                 }
             },
 


### PR DESCRIPTION
It's still not perfect, but it handles most code quite well.

The main case I'm aware of that this doesn't handle is a templated struct/class/union with a templated default type, e.g.:

```
template <class A = some_type<int>>
class Foo {
    ...
}
```

The nested <> aren't handled properly.  But regex isn't really suited to handling matched nested pairs, so this seems reasonable to not handle for now.
