### PR TITLE
Fixed typo in config/default/keys.json

### DIFF
--- a/app/config/default/keys.json
+++ b/app/config/default/keys.json
@@ -97,7 +97,7 @@
         },
         "Edit:Remove Word Right": {
             "win": "Ctrl-Delete",
-            "mac": "Alt-Delete"
+            "mac": "Alt-D|Alt-Delete"
         },
         "Cursor:File Start": {
             "mac": "Command-Up",


### PR DESCRIPTION
The standard shortcut for `Edit:Remove Word Right` on Mac is Alt-Delete, not Alt-D. The Windows shortcut is Ctrl-Delete, so I suppose this was just a typo.
