### PR TITLE
Exclude git and DS_Store when not in project root

### DIFF
--- a/app/config/default/preferences.json
+++ b/app/config/default/preferences.json
@@ -13,7 +13,7 @@
         "fontFamily": "'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace",
         "fontSize": 12,
         "globalAutoRevert": false,
-        "gotoExclude": ["/.git/*", "*/.zedstate", "/.DS_Store"],
+        "gotoExclude": ["*/.git/*", "*/.zedstate", "*/.DS_Store"],
         "highlightActiveLine": true,
         "highlightGutterLine": true,
         "highlightSelectedWord": true,


### PR DESCRIPTION
Make git and DS_Store files excluded by default, even when they are not at the root of the project.
