### PR TITLE
Explicitly make node_modules depend on package.json

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ endif
 nw/download-all: nw/download/node-webkit-$(NW_VERSION)-linux-x64 nw/download/node-webkit-$(NW_VERSION)-linux-ia32 nw/download/node-webkit-$(NW_VERSION)-osx-ia32 nw/download/node-webkit-$(NW_VERSION)-win-ia32
 
 apps-npm: app/node_modules
-app/node_modules:
+app/node_modules: app/package.json
 	cd app; npm install
 
 apps-mac: release/zed-mac-v$(ZED_VERSION).tar.gz


### PR DESCRIPTION
should prevent build failures when package.json is updated (e.g. new dependency added) but a stale app.nw (or a stale node_modules?) is used anyway
