### PR TITLE
hack to get restoring window size and position to work in linux

### DIFF
--- a/app/js/window.nw.js
+++ b/app/js/window.nw.js
@@ -65,7 +65,7 @@ define(function(require, exports, module) {
                 setTimeout(function() {
                     win.y = bounds.top;
                     win.height = bounds.height;
-                }, 500);
+                }, 10);
                 
                 if(bounds.isMaximized) {
                     win.maximize();


### PR DESCRIPTION
Fixes #428.  It seems like the problem is that only the width or height gets set and the other gets stuck at either 800 or 600.  I just threw a timeout around setting height and y and now it seems to work.  At least in cinnamon in Linux Mint 17.
