### PR TITLE
Implement Edit:Open Live Above and Edit:Open Line Below.

### DIFF
--- a/app/config/default/command/open_line.js
+++ b/app/config/default/command/open_line.js
@@ -1,0 +1,13 @@
+var session = require("zed/session");
+
+module.exports = function(info){
+    var pos = info.inputs.cursor;
+    var lines = info.inputs.lines;
+    var row = pos.row;
+
+    pos.column = 0;
+    pos.row += info.go;
+    session.insert(info.path, pos, (lines[row].match(/^\s+/) || [""])[0] + "\n");
+    session.callCommand(info.path, info.go === 0 ? "Cursor:Up" : "Cursor:Down");
+    session.callCommand(info.path, "Cursor:Line End");
+};

--- a/app/config/default/commands.json
+++ b/app/config/default/commands.json
@@ -228,19 +228,19 @@
             "readOnly": true
         },
         "Edit:Open Line Above": {
-            scriptUrl: "./command/open_line.js",
-            go: 0,
-            inputs: {
-                cursor: true,
-                lines: true
+            "scriptUrl": "./command/open_line.js",
+            "go": 0,
+            "inputs": {
+                "cursor": true,
+                "lines": true
             }
         },
         "Edit:Open Line Below": {
-            scriptUrl: "./command/open_line.js",
-            go: 1,
-            inputs: {
-                cursor: true,
-                lines: true
+            "scriptUrl": "./command/open_line.js",
+            "go": 1,
+            "inputs": {
+                "cursor": true,
+                "lines": true
             }
         },
         "Edit:Trim Whitespace": {

--- a/app/config/default/commands.json
+++ b/app/config/default/commands.json
@@ -227,6 +227,22 @@
             "value": "vim",
             "readOnly": true
         },
+        "Edit:Open Line Above": {
+            scriptUrl: "./command/open_line.js",
+            go: 0,
+            inputs: {
+                cursor: true,
+                lines: true
+            }
+        },
+        "Edit:Open Line Below": {
+            scriptUrl: "./command/open_line.js",
+            go: 1,
+            inputs: {
+                cursor: true,
+                lines: true
+            }
+        },
         "Edit:Trim Whitespace": {
             "doc": "This command will strip spaces and tabs from the end of every line (but not the line containing the cursor), and also ensures that the document ends with one and only one newline character.",
             "scriptUrl": "./command/stripper.js",

--- a/app/config/default/keys.json
+++ b/app/config/default/keys.json
@@ -80,6 +80,8 @@
             "mac": "Command-L"
         },
         "Help:Commands": "F1",
+        "Edit:Open Line Above": "Alt-Enter",
+        "Edit:Open Line Below": "Shift-Enter",
         "Edit:Overwrite Mode": "Insert",
         "Edit:Remove Word Left": {
             "win": "Ctrl-Backspace",

--- a/app/config/default/keys.json
+++ b/app/config/default/keys.json
@@ -80,8 +80,8 @@
             "mac": "Command-L"
         },
         "Help:Commands": "F1",
-        "Edit:Open Line Above": "Alt-Enter",
-        "Edit:Open Line Below": "Shift-Enter",
+        "Edit:Open Line Above": "Alt-Enter|Alt-O",
+        "Edit:Open Line Below": "Shift-Enter|Alt-o",
         "Edit:Overwrite Mode": "Insert",
         "Edit:Remove Word Left": {
             "win": "Ctrl-Backspace",

--- a/app/config/default/keys.json
+++ b/app/config/default/keys.json
@@ -80,8 +80,8 @@
             "mac": "Command-L"
         },
         "Help:Commands": "F1",
-        "Edit:Open Line Above": "Alt-Enter|Alt-O",
-        "Edit:Open Line Below": "Shift-Enter|Alt-o",
+        "Edit:Open Line Above": "Alt-Enter|Alt-Shift-O",
+        "Edit:Open Line Below": "Shift-Enter|Alt-O",
         "Edit:Overwrite Mode": "Insert",
         "Edit:Remove Word Left": {
             "win": "Ctrl-Backspace",


### PR DESCRIPTION
Let's start with an easy one ;-)

`Edit:Open Line Above` corresponds to Vim's `O` command and `Edit:Open Line Below` corresponds to `o`. I have defined the default keybinds as `Alt-Enter` and `Shift-Enter` because I think that makes most sense: these are "alternate" behaviors for what happens when you press enter. But I also added `Alt-o` and `Alt-O` to be consistent with the other Vim-y keybinds we have.