### PR TITLE
Implement paragraph-wise motion and selection.

### DIFF
--- a/app/config/default/command/open_line.js
+++ b/app/config/default/command/open_line.js
@@ -1,0 +1,13 @@
+var session = require("zed/session");
+
+module.exports = function(info){
+    var pos = info.inputs.cursor;
+    var lines = info.inputs.lines;
+    var row = pos.row;
+
+    pos.column = 0;
+    pos.row += info.go;
+    session.insert(info.path, pos, (lines[row].match(/^\s+/) || [""])[0] + "\n");
+    session.callCommand(info.path, info.go === 0 ? "Cursor:Up" : "Cursor:Down");
+    session.callCommand(info.path, "Cursor:Line End");
+};

--- a/app/config/default/command/paragraph.js
+++ b/app/config/default/command/paragraph.js
@@ -1,0 +1,37 @@
+var session = require("zed/session");
+
+
+function movement(info, row, regex, command) {
+    var line = true;
+    do {
+        row += info.go;
+        session.callCommand(info.path, command);
+        line = info.inputs.lines[row];
+    }
+    while (line && !line.match(regex));
+    return row;
+}
+
+
+module.exports = function(info){
+    var row = info.inputs.cursor.row;
+    var command = info.go < 0 ? "Cursor:Up" : "Cursor:Down";
+    var empty_line = /^\s*$/;
+
+    // If we're on an empty line, move to the first non-empty.
+    if (info.inputs.lines[row].match(empty_line)) {
+        row = movement(info, row, /\S/, command);
+    }
+
+    // Continue moving to the next empty line.
+    row = movement(info, row, empty_line, command);
+
+    // FIXME: This is a workaround for the cursor going off the screen.
+    session.callCommand(info.path, "Cursor:Center");
+
+    if (info.select) {
+        command = info.go > 0 ? "Select:Up" : "Select:Down";
+        info.go *= -1;
+        movement(info, row, empty_line, command);
+    }
+};

--- a/app/config/default/commands.json
+++ b/app/config/default/commands.json
@@ -264,6 +264,31 @@
                 "preferences": true
             }
         },
+        "Cursor:Paragraph Up": {
+            "scriptUrl": "./command/paragraph.js",
+            "go": -1,
+            "inputs": {
+                "cursor": true,
+                "lines": true
+            }
+        },
+        "Cursor:Paragraph Down": {
+            "scriptUrl": "./command/paragraph.js",
+            "go": 1,
+            "inputs": {
+                "cursor": true,
+                "lines": true
+            }
+        },
+        "Select:Paragraph": {
+            "scriptUrl": "./command/paragraph.js",
+            "go": -1,
+            "select": true,
+            "inputs": {
+                "cursor": true,
+                "lines": true
+            }
+        },
         "Find:Find In Project Internal": {
             "doc": "Recursively search all files within the entire project.",
             "scriptUrl": "./command/search.js",

--- a/app/config/default/commands.json
+++ b/app/config/default/commands.json
@@ -228,19 +228,19 @@
             "readOnly": true
         },
         "Edit:Open Line Above": {
-            scriptUrl: "./command/open_line.js",
-            go: 0,
-            inputs: {
-                cursor: true,
-                lines: true
+            "scriptUrl": "./command/open_line.js",
+            "go": 0,
+            "inputs": {
+                "cursor": true,
+                "lines": true
             }
         },
         "Edit:Open Line Below": {
-            scriptUrl: "./command/open_line.js",
-            go: 1,
-            inputs: {
-                cursor: true,
-                lines: true
+            "scriptUrl": "./command/open_line.js",
+            "go": 1,
+            "inputs": {
+                "cursor": true,
+                "lines": true
             }
         },
         "Edit:Trim Whitespace": {

--- a/app/config/default/commands.json
+++ b/app/config/default/commands.json
@@ -227,6 +227,22 @@
             "value": "vim",
             "readOnly": true
         },
+        "Edit:Open Line Above": {
+            scriptUrl: "./command/open_line.js",
+            go: 0,
+            inputs: {
+                cursor: true,
+                lines: true
+            }
+        },
+        "Edit:Open Line Below": {
+            scriptUrl: "./command/open_line.js",
+            go: 1,
+            inputs: {
+                cursor: true,
+                lines: true
+            }
+        },
         "Edit:Trim Whitespace": {
             "doc": "This command will strip spaces and tabs from the end of every line (but not the line containing the cursor), and also ensures that the document ends with one and only one newline character.",
             "scriptUrl": "./command/stripper.js",

--- a/app/config/default/keys.json
+++ b/app/config/default/keys.json
@@ -48,6 +48,7 @@
         "Select:Right": "Shift-Right|Alt-Shift-L",
         "Select:Page Down": "Shift-PageDown",
         "Select:Page Up": "Shift-PageUp",
+        "Select:Paragraph": "Alt-P",
         "Select:To Matching Brace": "Ctrl-Shift-5",
         "Select:Duplicate": {
             "win": "Ctrl-Shift-D",

--- a/app/config/default/keys.json
+++ b/app/config/default/keys.json
@@ -80,6 +80,8 @@
             "mac": "Command-L"
         },
         "Help:Commands": "F1",
+        "Edit:Open Line Above": "Alt-Enter",
+        "Edit:Open Line Below": "Shift-Enter",
         "Edit:Overwrite Mode": "Insert",
         "Edit:Remove Word Left": {
             "win": "Ctrl-Backspace",

--- a/app/config/default/keys.json
+++ b/app/config/default/keys.json
@@ -80,8 +80,8 @@
             "mac": "Command-L"
         },
         "Help:Commands": "F1",
-        "Edit:Open Line Above": "Alt-Enter",
-        "Edit:Open Line Below": "Shift-Enter",
+        "Edit:Open Line Above": "Alt-Enter|Alt-O",
+        "Edit:Open Line Below": "Shift-Enter|Alt-o",
         "Edit:Overwrite Mode": "Insert",
         "Edit:Remove Word Left": {
             "win": "Ctrl-Backspace",

--- a/app/config/default/keys.json
+++ b/app/config/default/keys.json
@@ -99,6 +99,8 @@
             "mac": "Command-Down|Alt-Shift-G",
             "win": "Ctrl-End|Alt-Shift-G"
         },
+        "Cursor:Paragraph Up": "Alt-Up",
+        "Cursor:Paragraph Down": "Alt-Down",
         "Cursor:Up": {
             "mac": "Up|Ctrl-P|Alt-K",
             "win": "Up|Alt-K"


### PR DESCRIPTION
Ah, apologies, this PR also includes the other one for open_line.js. Merge that one first and then this diff will look sensible ;-)

Let me know what you think about the keybinds. I wanted `Ctrl+Up/Down` for the motion and `Alt-h` (emacs style) for the selection, but those were all taken, so I kinda just grabbed whatever was available.