### PR TITLE
add back <PageUp> and <PageDown>

### DIFF
--- a/app/js/lib/vim_patch.js
+++ b/app/js/lib/vim_patch.js
@@ -1,6 +1,10 @@
 define(function(require, exports, module) {
     // Monkey patch vim mode
     var vimKeyBindings = require("ace/keyboard/vim");
+    var scrollKeys = [
+            { keys: '<PageDown>', type: 'motion', motion: 'moveByScroll', motionArgs: { forward: true, explicitRepeat: true }},
+            { keys: '<PageUp>', type: 'motion', motion: 'moveByScroll', motionArgs: { forward: false, explicitRepeat: true }},
+        ];
 
     function patchVimKeys() {
         var vimKeys = vimKeyBindings.handler.defaultKeymap;
@@ -10,6 +14,9 @@ define(function(require, exports, module) {
                 vimKeys.splice(i, 1);
                 i--;
             }
+        }
+        for(key in scrollKeys) {
+            vimKeys.push(key);
         }
     }
     patchVimKeys();


### PR DESCRIPTION
As <PageUp> and <PageDown> are bound to control keys in the vim
keyboard binding, we have to bind them explicitly to make them
work.  This patch makes <PageUp> and <PageDown> equivalent to
vim's <C-u> and <C-d>.