### PR TITLE
also remove keyToKey bindings to control keys in vim mode

### DIFF
--- a/app/js/lib/vim_patch.js
+++ b/app/js/lib/vim_patch.js
@@ -6,7 +6,7 @@ define(function(require, exports, module) {
         var vimKeys = vimKeyBindings.handler.defaultKeymap;
         for(var i = 0; i < vimKeys.length; i++) {
             var key = vimKeys[i];
-            if(key.keys.indexOf("<C-") === 0) {
+            if(key.keys.indexOf("<C-") === 0 || (key.type == "keyToKey" && key.toKeys.indexOf("<C-") === 0)) {
                 vimKeys.splice(i, 1);
                 i--;
             }


### PR DESCRIPTION
This will not remove bindings to keys that are mapped to control
keys by the vim-keyboard mapping.  The result is that the page-up
and page-down keys will work again in vim-keyboard mode.