### PR TITLE
Switch to Last Focused Project on Launch

### DIFF
--- a/app/background.chrome.js
+++ b/app/background.chrome.js
@@ -195,8 +195,12 @@ window.registerWindow = function(title, url, win) {
     }
     openProjects[url] = {
         win: win,
-        title: title
+        title: title,
+        lastFocus: new Date()
     };
+    win.contentWindow.addEventListener('focus', function() {
+        openProjects[url].lastFocus = new Date();
+    });
     win.onClosed.addListener(function() {
         delete openProjects[url];
         saveOpenWindows();
@@ -209,8 +213,12 @@ window.getOpenWindows = function() {
     Object.keys(openProjects).forEach(function(url) {
         wins.push({
             title: openProjects[url].title,
-            url: url
+            url: url,
+            lastFocus: openProjects[url].lastFocus
         });
+    });
+    wins.sort(function(a, b) {
+        return a.lastFocus < b.lastFocus;
     });
     return wins;
 };
@@ -235,8 +243,8 @@ function saveOpenWindows() {
 }
 
 function restoreOpenWindows(e) {
-    var wins = chrome.app.window.getAll();
-    if (wins.length) return wins[0].focus();
+    var wins = window.getOpenWindows();
+    if (wins.length) return openProjects[wins[0].url].win.focus();
     
     ignoreClose = false;
     console.log("On launched", e);

--- a/app/background.chrome.js
+++ b/app/background.chrome.js
@@ -235,6 +235,9 @@ function saveOpenWindows() {
 }
 
 function restoreOpenWindows(e) {
+    var wins = chrome.app.window.getAll();
+    if (wins.length) return wins[0].focus();
+    
     ignoreClose = false;
     console.log("On launched", e);
     chrome.storage.local.get("openWindows", function(result) {


### PR DESCRIPTION
This change is for the Chrome app only.  I've noticed a lot of chrome apps in Chrome OS will let you switch to an open window by selecting it from the launcher.  I've grown accustomed to doing this to switch windows, but zed always launches the new project picker.  This pull request changes it to instead switch to the most recently used zed window.  I've also tested this in linux.  I'm not sure if this behavior is desirable as a default or not.

This also puts the projects in most recently used order in the window list command.