### PR TITLE
Fix file-tree scrollbars styles

### DIFF
--- a/app/config/default/window_theme/zed_dark.css
+++ b/app/config/default/window_theme/zed_dark.css
@@ -39,6 +39,7 @@ body .ace_line-hover {
 body .ace_editor.ace_autocomplete .ace_active-line {
     background-color: #555 !important;
 }
+body .tree,
 body .dynatree-container {
     background-color: #222;
 }

--- a/app/css/editor.css
+++ b/app/css/editor.css
@@ -336,7 +336,6 @@ body .ace_autocomplete .ace_line {
     bottom: 0;
     width: 300px;
     border-right: solid 1px black;
-    background: #fff;
     padding: 0;
     z-index: 999;
     font-family:'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
@@ -421,6 +420,9 @@ body.custom-scroll ::-webkit-scrollbar-thumb:horizontal {
 }
 body.custom-scroll ::-webkit-scrollbar-thumb:hover {
     -webkit-box-shadow: inset 0 0 0 1px rgba(128, 128, 128, 0.9), inset 0 0 0 4px rgba(128, 128, 128, 0.9);
+}
+body.custom-scroll ::-webkit-scrollbar-corner {
+    background: none;
 }
 /* Markers */
  .marker-highlight-warning {

--- a/app/css/ui.dynatree.css
+++ b/app/css/ui.dynatree.css
@@ -12,6 +12,7 @@ ul.dynatree-container
 	border: 1px dotted gray;
 	overflow: auto;
 	height: 100%; /* issue 263 */
+	box-sizing: border-box;
 }
 
 ul.dynatree-container ul


### PR DESCRIPTION
Fixing some styles for file-tree scrollbars.
Tested on Windows and Chrome OS with dark and light theme.

![bugged](https://cloud.githubusercontent.com/assets/1329477/7458174/1d1115de-f29b-11e4-927c-3cd108d5aa64.png)

Not sure if I able to edit `app/css/ui.dynatree.css` but it needs to have a proper `box-sizing` because of paddings.
